### PR TITLE
Defaults

### DIFF
--- a/.io.livecode.ch/_site/index.html
+++ b/.io.livecode.ch/_site/index.html
@@ -16,16 +16,71 @@ Come up with your own examples and use the save icon to update the URL to a perm
 </p>
 
 <p><b><font size="4">Which language would you like to break?</font></b><br/>
-<b>Java</b> / <a href="unsound/scala">Scala</a></p>
+<font color="red">Java</font> / <a style="color:grey" href="unsound/scala">Scala</a></p>
 
 <ul style="list-style-type: none; margin-left: -1.5em">
-<li><a style="color:#551A8B" href="#2e4392fc6392155ecfdb91c5fd183a01">Unsound.java in Java 8</a> (the first program we broke Java with, derived from <a href="unsound/scala#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala</a>)</li>
-<li><a href="#1425505f7c9f62770632bff6e520b866">Unsound.java in Java 9</a> (sometimes compilers incorrectly reject valid code)</li>
-<li><a href="#cb32d4994710d626c877d2387712be99">Unsound9.java in Java 9</a> (we even broke Java in the future) </li>
-<li><a href="#e544cf105b4d301bfb821ff1a64ba833">UnsoundSpec.java in Java 6</a> (incorrectly rejected unsound program that has been valid since Java 5 in 2004)</li>
-<li><a href="#c27c67c524eade3bbe15b1993b0a846a">Nullless.java in Java 8</a> (this program has no occurence of <tt>null</tt>)</a></li>
-<li><a href="#46b717349115fa58e2090cab119da61c">SingleParameters.java in Java 8</a> (every class and method in this program has exactly one parameter)</li>
+<li><a id="e0" href="#2e4392fc6392155ecfdb91c5fd183a01">Unsound.java in Java 8</a> (the first program we broke Java with, derived from <a style="color:grey" href="unsound/scala#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala</a>)</li>
+<li><a id="e1" href="#1425505f7c9f62770632bff6e520b866">Unsound.java in Java 9</a> (sometimes compilers incorrectly reject valid code)</li>
+<li><a id="e2" href="#cb32d4994710d626c877d2387712be99">Unsound9.java in Java 9</a> (we even broke Java in the future) </li>
+<li><a id="e3" href="#e544cf105b4d301bfb821ff1a64ba833">UnsoundSpec.java in Java 6</a> (incorrectly rejected unsound program that has been valid since Java 5 in 2004)</li>
+<li><a id="e4" href="#c27c67c524eade3bbe15b1993b0a846a">Nullless.java in Java 8</a> (this program has no occurence of <tt>null</tt>)</a></li>
+<li><a id="e5" href="#46b717349115fa58e2090cab119da61c">SingleParameters.java in Java 8</a> (every class and method in this program has exactly one parameter)</li>
 </ul>
+
+<script type="text/javascript">
+function rehash() {
+ for (var i=0; i<=5; i++) {
+  var link = document.getElementById("e" + i);
+  link.style.color = "grey";
+  link.style["text-decoration"] = "underline";
+ }
+ var hash = window.location.hash;
+ var index = hash.indexOf("#");
+ if (index < 0) {
+  last = document.getElementById("e0");
+  last.style.color = "red";
+  last.style["text-decoration"] = "none";
+ } else {
+  hash = hash.substring(index);
+  for (var i=0; i<=5; i++) {
+   var link = document.getElementById("e" + i);
+   var href = link.href;
+   href = href.substring(href.indexOf("#"));
+   if (href == hash) {
+    last = link;
+    last.style.color = "red";
+    last.style["text-decoration"] = "none";
+   }
+  }
+ }
+}
+rehash();
+if ("onhashchange" in window) {
+ window.onhashchange = rehash;
+} else {
+ var last = null;
+ function paintlinks() {
+  if (last) {
+   last.style.color = "grey";
+   last.style["text-decoration"] = "underline";
+  }
+  last = this;
+  last.style.color = "red";
+  last.style["text-decoration"] = "none";
+ }
+ for (var i=0; i<=5; i++) {
+  var link = document.getElementById("e" + i);
+  link.style.color = "grey";
+  if (link.addEventListener) {
+   link.addEventListener("click",paintlinks,false);
+  } else if (link.attachEvent) {
+   link.attachEvent("onclick",paintlinks);
+  } else {
+   link.onclick=rememberLink;
+  }
+ }
+}
+</script>
 
 <div class="live norun" id="ex1">
 class Unsound {

--- a/.io.livecode.ch/_site/index.html
+++ b/.io.livecode.ch/_site/index.html
@@ -16,7 +16,7 @@ Come up with your own examples and use the save icon to update the URL to a perm
 </p>
 
 <p><b><font size="4">Which language would you like to break?</font></b><br/>
-Java / <a href="unsound/scala">Scala</a></p>
+<b>Java</b> / <a href="unsound/scala">Scala</a></p>
 
 <ul style="list-style-type: none; margin-left: -1.5em">
 <li><a href="#2e4392fc6392155ecfdb91c5fd183a01">Unsound.java in Java 8</a> (the first program we broke Java with, derived from <a href="unsound/scala#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala</a>)</li>

--- a/.io.livecode.ch/_site/index.html
+++ b/.io.livecode.ch/_site/index.html
@@ -29,20 +29,20 @@ Come up with your own examples and use the save icon to update the URL to a perm
 
 <div class="live norun" id="ex1">
 class Unsound {
-  static class Constrain%lt;A, B extends A&gt; {}
-  static class Bind%lt;A&gt; {
-    %lt;B extends A&gt;
-    A upcast(Constrain%lt;A,B&gt; constrain, B b) {
+  static class Constrain&lt;A, B extends A&gt; {}
+  static class Bind&lt;A&gt; {
+    &lt;B extends A&gt;
+    A upcast(Constrain&lt;A,B&gt; constrain, B b) {
       return b;
     }
   }
-  static %lt;T,U&gt; U coerce(T t) {
-    Constrain%lt;U,? super T&gt; constrain = null;
-    Bind%lt;U&gt; bind = new Bind%lt;U&gt;();
+  static &lt;T,U&gt; U coerce(T t) {
+    Constrain&lt;U,? super T&gt; constrain = null;
+    Bind&lt;U&gt; bind = new Bind&lt;U&gt;();
     return bind.upcast(constrain, t);
   }
   public static void main(String[] args) {
-    String zero = Unsound.%lt;Integer,String&gt;coerce(0);
+    String zero = Unsound.&lt;Integer,String&gt;coerce(0);
   }
 }
 </div>

--- a/.io.livecode.ch/_site/index.html
+++ b/.io.livecode.ch/_site/index.html
@@ -11,14 +11,14 @@
 <p>
 We, <a href="http://namin.net/">Nada Amin</a> and <a href="http://www.cs.cornell.edu/~ross/">Ross Tate</a>, broke the Java and Scala type systems!</br>
 Try it out for yourself by running the examples, which throw cast exceptions even though they contain no casts &darr;</br>
-Read our paper <cite>Java and Scala's Type Systems are Unsound</cite> to get a step-by-step walkthrough of how these examples work &rarr;</br>
+Read our paper <cite>Java and Scala's Type Systems are Unsound</cite> to learn how these examples work &rarr;</br>
 Come up with your own examples and use the save icon to update the URL to a permalink to your code &#8625;
 </p>
 
-<div>Java / <a href="unsound/scala">Scala</a>
-</div>
+<p><b><font size="4">Which language would you like to break?</font></b><br/>
+Java / <a href="unsound/scala">Scala</a></p>
 
-<ul style="list-style-type: none; margin-left: -2em; margin-top: .4em">
+<ul style="list-style-type: none; margin-left: -1.5em">
 <li><a href="#2e4392fc6392155ecfdb91c5fd183a01">Unsound.java in Java 8</a> (the first program we broke Java with, derived from <a href="unsound/scala#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala</a>)</li>
 <li><a href="#1425505f7c9f62770632bff6e520b866">Unsound.java in Java 9</a> (sometimes compilers incorrectly reject valid code)</li>
 <li><a href="#cb32d4994710d626c877d2387712be99">Unsound9.java in Java 9</a> (we even broke Java in the future) </li>

--- a/.io.livecode.ch/_site/index.html
+++ b/.io.livecode.ch/_site/index.html
@@ -19,7 +19,7 @@ Come up with your own examples and use the save icon to update the URL to a perm
 <b>Java</b> / <a href="unsound/scala">Scala</a></p>
 
 <ul style="list-style-type: none; margin-left: -1.5em">
-<li><a href="#2e4392fc6392155ecfdb91c5fd183a01">Unsound.java in Java 8</a> (the first program we broke Java with, derived from <a href="unsound/scala#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala</a>)</li>
+<li><a style="color:#551A8B" href="#2e4392fc6392155ecfdb91c5fd183a01">Unsound.java in Java 8</a> (the first program we broke Java with, derived from <a href="unsound/scala#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala</a>)</li>
 <li><a href="#1425505f7c9f62770632bff6e520b866">Unsound.java in Java 9</a> (sometimes compilers incorrectly reject valid code)</li>
 <li><a href="#cb32d4994710d626c877d2387712be99">Unsound9.java in Java 9</a> (we even broke Java in the future) </li>
 <li><a href="#e544cf105b4d301bfb821ff1a64ba833">UnsoundSpec.java in Java 6</a> (incorrectly rejected unsound program that has been valid since Java 5 in 2004)</li>
@@ -29,25 +29,20 @@ Come up with your own examples and use the save icon to update the URL to a perm
 
 <div class="live norun" id="ex1">
 class Unsound {
-  static class Bind&lt;A&gt; {
-    class Curry&lt;B extends A&gt; {
-	  A curry(B b) { return b; }
-	}
-    &lt;B extends A&gt;
-    Curry&lt;B&gt; upcast(Constraint&lt;B&gt; constraint) {
-      return new Curry&lt;B&gt;();
+  static class Constrain<A, B extends A> {}
+  static class Bind<A> {
+    <B extends A>
+    A upcast(Constrain<A,B> constrain, B b) {
+      return b;
     }
-    class Constraint&lt;B extends A&gt; {}
-	&lt;B&gt; A coerce(B t) {
-	  Constraint&lt;? super B&gt; constraint = null;
-	  return upcast(constraint).curry(t);
-	}
   }
-  static &lt;T,U&gt; U coerce(T t) {
-    return new Bind&lt;U&gt;().&lt;T&gt;coerce(t);
+  static <T,U> U coerce(T t) {
+    Constrain<U,? super T> constrain = null;
+    Bind<U> bind = new Bind<U>();
+    return bind.upcast(constrain, t);
   }
   public static void main(String[] args) {
-    String zero = Unsound.&lt;Integer,String&gt;coerce(0);
+    String zero = Unsound.<Integer,String>coerce(0);
   }
 }
 </div>
@@ -57,7 +52,7 @@ class Unsound {
 set -e -v
 
 ### PICK VERSION
-export JAVA_HOME=/usr/lib/jvm/java-7-oracle
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle
 export PATH=$JAVA_HOME/bin:$PATH
 
 ### CHECK VERSION

--- a/.io.livecode.ch/_site/index.html
+++ b/.io.livecode.ch/_site/index.html
@@ -1,26 +1,31 @@
 {% extends "base_livecode.html" %}
 
-{% block title %}Unsound Playground{% endblock %}
+{% block title %}The Unsound Playground{% endblock %}
 
 {% block content %}
+
+<div style="float:right;">
+<a href="https://raw.githubusercontent.com/namin/unsound/master/doc/unsound-oopsla16.pdf"><img style="border: 2px solid black" src="http://raw.githubusercontent.com/namin/unsound/master/doc/unsound-oopsla16.png"></img></a>
+</div>
+
+<p>
+We, <a href="http://namin.net/">Nada Amin</a> and <a href="http://www.cs.cornell.edu/~ross/">Ross Tate</a>, broke the Java and Scala type systems!</br>
+Try it out for yourself by running the examples, which throw cast exceptions even though they contain no casts &darr;</br>
+Read our paper <cite>Java and Scala's Type Systems are Unsound</cite> to get a step-by-step walkthrough of how these examples work &rarr;</br>
+Come up with your own examples and use the save icon to update the URL to a permalink to your code &#8625;
+</p>
 
 <div>Java / <a href="unsound/scala">Scala</a>
 </div>
 
-<div style="float:right;">
-<a href="https://github.com/namin/unsound/blob/master/doc/unsound-oopsla16.pdf"><img src="http://raw.githubusercontent.com/namin/unsound/master/doc/unsound-oopsla16.png"></img></a>
-</div>
-
-<p>
-Try these examples, each is a valid Java program according to the specification:
-<ul>
-<li><a href="#2e4392fc6392155ecfdb91c5fd183a01">Unsound.java in Java 8 (compiles, runs to cast exception)</a></li>
-<li><a href="#1425505f7c9f62770632bff6e520b866">Unsound.java in Java 9 (does not compile)</a></li>
-<li><a href="#cb32d4994710d626c877d2387712be99">Unsound9.java in Java 9 (compiles, runs to cast exception)</a></li>
-<li><a href="#e544cf105b4d301bfb821ff1a64ba833">UnsoundSpec.java in Java 6 (does not compile)</a></li>
-<li><a href="#c27c67c524eade3bbe15b1993b0a846a">Nullless.java in Java 8 (compiles, run to cast exception)</a></li>
+<ul style="list-style-type: none; margin-left: -2em; margin-top: .4em">
+<li><a href="#2e4392fc6392155ecfdb91c5fd183a01">Unsound.java in Java 8</a> (the first program we broke Java with, derived from <a href="unsound/scala#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala</a>)</li>
+<li><a href="#1425505f7c9f62770632bff6e520b866">Unsound.java in Java 9</a> (sometimes compilers incorrectly reject valid code)</li>
+<li><a href="#cb32d4994710d626c877d2387712be99">Unsound9.java in Java 9</a> (we even broke Java in the future) </li>
+<li><a href="#e544cf105b4d301bfb821ff1a64ba833">UnsoundSpec.java in Java 6</a> (incorrectly rejected unsound program that has been valid since Java 5 in 2004)</li>
+<li><a href="#c27c67c524eade3bbe15b1993b0a846a">Nullless.java in Java 8</a> (this program has no occurence of <tt>null</tt>)</a></li>
+<li><a href="#46b717349115fa58e2090cab119da61c">SingleParameters.java in Java 8</a> (every class and method in this program has exactly one parameter)</li>
 </ul>
-</p>
 
 <div class="live norun" id="ex1">
 class Unsound {

--- a/.io.livecode.ch/_site/index.html
+++ b/.io.livecode.ch/_site/index.html
@@ -29,20 +29,20 @@ Come up with your own examples and use the save icon to update the URL to a perm
 
 <div class="live norun" id="ex1">
 class Unsound {
-  static class Constrain<A, B extends A> {}
-  static class Bind<A> {
-    <B extends A>
-    A upcast(Constrain<A,B> constrain, B b) {
+  static class Constrain%lt;A, B extends A&gt; {}
+  static class Bind%lt;A&gt; {
+    %lt;B extends A&gt;
+    A upcast(Constrain%lt;A,B&gt; constrain, B b) {
       return b;
     }
   }
-  static <T,U> U coerce(T t) {
-    Constrain<U,? super T> constrain = null;
-    Bind<U> bind = new Bind<U>();
+  static %lt;T,U&gt; U coerce(T t) {
+    Constrain%lt;U,? super T&gt; constrain = null;
+    Bind%lt;U&gt; bind = new Bind%lt;U&gt;();
     return bind.upcast(constrain, t);
   }
   public static void main(String[] args) {
-    String zero = Unsound.<Integer,String>coerce(0);
+    String zero = Unsound.%lt;Integer,String&gt;coerce(0);
   }
 }
 </div>

--- a/.io.livecode.ch/_site/scala/index.html
+++ b/.io.livecode.ch/_site/scala/index.html
@@ -11,14 +11,14 @@
 <p>
 We, <a href="http://namin.net/">Nada Amin</a> and <a href="http://www.cs.cornell.edu/~ross/">Ross Tate</a>, broke the Java and Scala type systems!</br>
 Try it out for yourself by running the examples, which throw cast exceptions even though they contain no casts &darr;</br>
-Read our paper <cite>Java and Scala's Type Systems are Unsound</cite> to get a step-by-step walkthrough of how these examples work &rarr;</br>
+Read our paper <cite>Java and Scala's Type Systems are Unsound</cite> to learn how these examples work &rarr;</br>
 Come up with your own examples and use the save icon to update the URL to a permalink to your code &#8625;
 </p>
 
-<div><a href="../unsound">Java</a> / Scala
-</div>
+<p><b><font size="4">Which language would you like to break?</font></b><br/>
+Java / <a href="unsound/scala">Scala</a></p>
 
-<ul style="list-style-type: none; margin-left: -2em; margin-top: .4em">
+<ul style="list-style-type: none; margin-left: -1.5em">
 <li><a href="#9e239ac3389702ac3c41acf1af781d56">unsound.scala in Scala 2.11.8</a></li>
 <li><a href="#6335177464268d7a08ac5ed03fee0989">unsound.scala in Scala 2.9.3</a> (incorrectly rejected by older compiler)</li>
 <li><a href="#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala in Scala 2.9.3</a> (the first program we broke Scala with)</li>

--- a/.io.livecode.ch/_site/scala/index.html
+++ b/.io.livecode.ch/_site/scala/index.html
@@ -16,7 +16,7 @@ Come up with your own examples and use the save icon to update the URL to a perm
 </p>
 
 <p><b><font size="4">Which language would you like to break?</font></b><br/>
-Java / <a href="unsound/scala">Scala</a></p>
+<a href="../unsound">Java</a> / Scala</p>
 
 <ul style="list-style-type: none; margin-left: -1.5em">
 <li><a href="#9e239ac3389702ac3c41acf1af781d56">unsound.scala in Scala 2.11.8</a></li>

--- a/.io.livecode.ch/_site/scala/index.html
+++ b/.io.livecode.ch/_site/scala/index.html
@@ -1,25 +1,30 @@
 {% extends "base_livecode.html" %}
 
-{% block title %}Unsound Playground{% endblock %}
+{% block title %}The Unsound Playground{% endblock %}
 
 {% block content %}
-<div><a href="../unsound">Java</a> / Scala
-</div>
 
 <div style="float:right;">
-<a href="https://github.com/namin/unsound/blob/master/doc/unsound-oopsla16.pdf"><img src="http://raw.githubusercontent.com/namin/unsound/master/doc/unsound-oopsla16.png"></img></a>
+<a href="https://raw.githubusercontent.com/namin/unsound/master/doc/unsound-oopsla16.pdf"><img style="border: 2px solid black" src="http://raw.githubusercontent.com/namin/unsound/master/doc/unsound-oopsla16.png"></img></a>
 </div>
 
 <p>
-Try these examples, each is a valid Scala program:
-<ul>
-<li><a href="#e7374b2bbcbd2e4fff52e729b9e5d646">unsound.scala in Scala 2.11.8 (compiles, runs to cast exception)</a></li>
-<li><a href="#18fa3ec8fdec51da937d9ac5a29d81f2">unsound.scala in Scala 2.9.3 (does not compile due to restrictions on dependent methods)</a></li>
-<li><a href="#c15a2fb8d0daed0dc6bddaf425bc64f9">unsound_legacy.scala in Scala 2.9.3 (compiles, runs to cast exception)</a></li>
-<li><a href="#59c713356ccc1e433c9c0fe7b45ec12b">unsoundForward.scala in Scala 2.11.8 (compiles, runs to cast exception -- courtesy of Dmitry Petrashko)</a></li>
-<li><a href="#6b41ca8cbab70dc955c6e35b929ccfcf">unsoundStatics.scala in Scala 2.11.8 (compiles, runs to cast exception -- courtesy of Dmitry Petrashko)</a></li>
-</ul>
+We, <a href="http://namin.net/">Nada Amin</a> and <a href="http://www.cs.cornell.edu/~ross/">Ross Tate</a>, broke the Java and Scala type systems!</br>
+Try it out for yourself by running the examples, which throw cast exceptions even though they contain no casts &darr;</br>
+Read our paper <cite>Java and Scala's Type Systems are Unsound</cite> to get a step-by-step walkthrough of how these examples work &rarr;</br>
+Come up with your own examples and use the save icon to update the URL to a permalink to your code &#8625;
 </p>
+
+<div><a href="../unsound">Java</a> / Scala
+</div>
+
+<ul style="list-style-type: none; margin-left: -2em; margin-top: .4em">
+<li><a href="#9e239ac3389702ac3c41acf1af781d56">unsound.scala in Scala 2.11.8</a></li>
+<li><a href="#6335177464268d7a08ac5ed03fee0989">unsound.scala in Scala 2.9.3</a> (incorrectly rejected by older compiler)</li>
+<li><a href="#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala in Scala 2.9.3</a> (the first program we broke Scala with)</li>
+<li><a href="#9ef5cf28bf42bc0aab48f65c1b9cad27">nullless.scala in Scala 2.11.8</a> (this program has no occurence of <tt>null</tt>, courtesy of <a href="https://d-d.me/">Dmitry Petrashko</a>)</li>
+<li><a href="#0f94d6013b70ba75d0c33d3943bfaf02">unsoundStatic.scala in Scala 2.11.8</a> (this program has no occurence of <tt>null</tt>, courtesy of <a href="https://d-d.me/">Dmitry Petrashko</a>)</li>
+</ul>
 
 <div class="live norun" id="ex1" data-mode="text/x-scala">
 object unsound {

--- a/.io.livecode.ch/_site/scala/index.html
+++ b/.io.livecode.ch/_site/scala/index.html
@@ -16,16 +16,71 @@ Come up with your own examples and use the save icon to update the URL to a perm
 </p>
 
 <p><b><font size="4">Which language would you like to break?</font></b><br/>
-<a href="../unsound">Java</a> / <b>Scala</b></p>
+<a style="color:grey" href="../unsound">Java</a> / <font color="red">Scala</font></p>
 
 <ul style="list-style-type: none; margin-left: -1.5em">
-<li><a style="color:#551A8B" href="#bc53cf1374c5181384667a960aa6d49c">unsoundMini.scala in Scala 2.11.8</a></li>
-<li><a href="#9e239ac3389702ac3c41acf1af781d56">unsound.scala in Scala 2.11.8</a></li>
-<li><a href="#6335177464268d7a08ac5ed03fee0989">unsound.scala in Scala 2.9.3</a> (incorrectly rejected by older compiler)</li>
-<li><a href="#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala in Scala 2.9.3</a> (the first program we broke Scala with)</li>
-<li><a href="#9ef5cf28bf42bc0aab48f65c1b9cad27">nullless.scala in Scala 2.11.8</a> (this program has no occurence of <tt>null</tt>, courtesy of <a href="https://d-d.me/">Dmitry Petrashko</a>)</li>
-<li><a href="#0f94d6013b70ba75d0c33d3943bfaf02">unsoundStatic.scala in Scala 2.11.8</a> (this program has no occurence of <tt>null</tt>, courtesy of <a href="https://d-d.me/">Dmitry Petrashko</a>)</li>
+<li><a id="e0" href="#bc53cf1374c5181384667a960aa6d49c">unsoundMini.scala in Scala 2.11.8</a></li>
+<li><a id="e1" href="#9e239ac3389702ac3c41acf1af781d56">unsound.scala in Scala 2.11.8</a></li>
+<li><a id="e2" href="#6335177464268d7a08ac5ed03fee0989">unsound.scala in Scala 2.9.3</a> (incorrectly rejected by older compiler)</li>
+<li><a id="e3" href="#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala in Scala 2.9.3</a> (the first program we broke Scala with)</li>
+<li><a id="e4" href="#9ef5cf28bf42bc0aab48f65c1b9cad27">nullless.scala in Scala 2.11.8</a> (this program has no occurence of <tt>null</tt>, courtesy of <a href="https://d-d.me/">Dmitry Petrashko</a>)</li>
+<li><a id="e5" href="#0f94d6013b70ba75d0c33d3943bfaf02">unsoundStatic.scala in Scala 2.11.8</a> (this program has no occurence of <tt>null</tt>, courtesy of <a href="https://d-d.me/">Dmitry Petrashko</a>)</li>
 </ul>
+
+<script type="text/javascript">
+function rehash() {
+ for (var i=0; i<=5; i++) {
+  var link = document.getElementById("e" + i);
+  link.style.color = "grey";
+  link.style["text-decoration"] = "underline";
+ }
+ var hash = window.location.hash;
+ var index = hash.indexOf("#");
+ if (index < 0) {
+  last = document.getElementById("e0");
+  last.style.color = "red";
+  last.style["text-decoration"] = "none";
+ } else {
+  hash = hash.substring(index);
+  for (var i=0; i<=5; i++) {
+   var link = document.getElementById("e" + i);
+   var href = link.href;
+   href = href.substring(href.indexOf("#"));
+   if (href == hash) {
+    last = link;
+    last.style.color = "red";
+    last.style["text-decoration"] = "none";
+   }
+  }
+ }
+}
+rehash();
+if ("onhashchange" in window) {
+ window.onhashchange = rehash;
+} else {
+ var last = null;
+ function paintlinks() {
+  if (last) {
+   last.style.color = "grey";
+   last.style["text-decoration"] = "underline";
+  }
+  last = this;
+  last.style.color = "red";
+  last.style["text-decoration"] = "none";
+ }
+ for (var i=0; i<=5; i++) {
+  var link = document.getElementById("e" + i);
+  link.style.color = "grey";
+  if (link.addEventListener) {
+   link.addEventListener("click",paintlinks,false);
+  } else if (link.attachEvent) {
+   link.attachEvent("onclick",paintlinks);
+  } else {
+   link.onclick=rememberLink;
+  }
+ }
+}
+</script>
 
 <div class="live norun" id="ex1" data-mode="text/x-scala">
 object unsoundMini {

--- a/.io.livecode.ch/_site/scala/index.html
+++ b/.io.livecode.ch/_site/scala/index.html
@@ -19,6 +19,7 @@ Come up with your own examples and use the save icon to update the URL to a perm
 <a href="../unsound">Java</a> / <b>Scala</b></p>
 
 <ul style="list-style-type: none; margin-left: -1.5em">
+<li><a style="color:#551A8B" href="#bc53cf1374c5181384667a960aa6d49c">unsoundMini.scala in Scala 2.11.8</a></li>
 <li><a href="#9e239ac3389702ac3c41acf1af781d56">unsound.scala in Scala 2.11.8</a></li>
 <li><a href="#6335177464268d7a08ac5ed03fee0989">unsound.scala in Scala 2.9.3</a> (incorrectly rejected by older compiler)</li>
 <li><a href="#a406d726d2fd1c7cf1b166db540fa1bf">legacy.scala in Scala 2.9.3</a> (the first program we broke Scala with)</li>
@@ -27,12 +28,12 @@ Come up with your own examples and use the save icon to update the URL to a perm
 </ul>
 
 <div class="live norun" id="ex1" data-mode="text/x-scala">
-object unsound {
+object unsoundMini {
   trait A { type L >: Any}
-  def id1(a: A, x: Any): a.L = x
+  def upcast(a: A, x: Any): a.L = x
   val p: A { type L <: Nothing } = null
-  def id2(x: Any): Nothing = id1(p, x)
-  id2("oh")
+  def coerce(x: Any): Nothing = upcast(p, x)
+  coerce("Uh oh!")
 }
 </div>
 
@@ -51,10 +52,11 @@ java -version
 scala -version
 
 ### COMPILE
-scalac unsound.scala
+cat $1 >unsoundMini.scala
+scalac unsoundMini.scala
 
 ### RUN
-scala unsound
+scala unsoundMini
 </div>
 
 {% endblock %}

--- a/.io.livecode.ch/_site/scala/index.html
+++ b/.io.livecode.ch/_site/scala/index.html
@@ -16,7 +16,7 @@ Come up with your own examples and use the save icon to update the URL to a perm
 </p>
 
 <p><b><font size="4">Which language would you like to break?</font></b><br/>
-<a href="../unsound">Java</a> / Scala</p>
+<a href="../unsound">Java</a> / <b>Scala</b></p>
 
 <ul style="list-style-type: none; margin-left: -1.5em">
 <li><a href="#9e239ac3389702ac3c41acf1af781d56">unsound.scala in Scala 2.11.8</a></li>

--- a/.io.livecode.ch/_site/scala/index.html
+++ b/.io.livecode.ch/_site/scala/index.html
@@ -29,9 +29,9 @@ Come up with your own examples and use the save icon to update the URL to a perm
 
 <div class="live norun" id="ex1" data-mode="text/x-scala">
 object unsoundMini {
-  trait A { type L >: Any}
+  trait A { type L &gt;: Any}
   def upcast(a: A, x: Any): a.L = x
-  val p: A { type L <: Nothing } = null
+  val p: A { type L &lt;: Nothing } = null
   def coerce(x: Any): Nothing = upcast(p, x)
   coerce("Uh oh!")
 }

--- a/SingleParameters.java
+++ b/SingleParameters.java
@@ -1,0 +1,20 @@
+class SingleParameters<Ignore> {
+  static class Bind<A> {
+    class Curry<B extends A> {
+      A curry(B b) { return b; }
+    }
+    <B extends A>
+    Curry<B> upcast(Constraint<B> constraint) {
+      return new Curry<B>();
+    }
+    class Constraint<B extends A> {}
+    <B> A coerce(B t) {
+      Constraint<? super B> constraint = null;
+      return upcast(constraint).curry(t);
+    }
+  }
+  public static void main(String[] args) {
+    Bind<String> bind = new Bind<String>();
+    String zero = bind.<Integer>coerce(0);
+  }
+}

--- a/legacy.scala
+++ b/legacy.scala
@@ -1,3 +1,4 @@
+object legacy {
   trait LowerBound[T] {
     type M >: T;
   }

--- a/legacy.scala
+++ b/legacy.scala
@@ -1,4 +1,3 @@
-object unsound_legacy {
   trait LowerBound[T] {
     type M >: T;
   }


### PR DESCRIPTION
Addressing Issue #2. With the e-mail tip you gave me, I figured out the Java default was the old version of SingleParameters.java. So I changed the default to Unsound.java. I liked the Scala default since it was small. So I made it unsoundMini.scala and added that as the first (default) example. That also makes it so that we have the same number of Java and Scala examples.

I then added some javascript to figure out what the current example is, make that red and no-underline, and make the rest grey. You should be able to test this out at http://io.livecode.ch/learn/rosstate/unsound
